### PR TITLE
fix handling of site.baseurl

### DIFF
--- a/404.html
+++ b/404.html
@@ -6,5 +6,5 @@ permalink: 404.html
 
 <div class="page">
   <h1 class="page-title">404: Page not found</h1>
-  <p class="lead">Sorry, we've misplaced that URL or it's pointing to something that doesn't exist. <a href="{{ site.baseurl }}">Head back home</a> to try finding it again.</p>
+  <p class="lead">Sorry, we've misplaced that URL or it's pointing to something that doesn't exist. <a href="{{ site.baseurl }}/">Head back home</a> to try finding it again.</p>
 </div>

--- a/README.md
+++ b/README.md
@@ -37,12 +37,12 @@ For links between pages to work, generate absolute links with
 `site.baseurl` liquid tag:
 
 ```
-[see citations]({{site.baseurl}}pages/citations
+[see citations]({{site.baseurl}}/pages/citations
 ```
 
 The example will link to the file `/pages/citations`. Also note that
 one does not need spaces between the configuration variable and the
-curly braces (i.e. `{{ site.baseurl }}` as typical seen), so I avoid
+curly braces (i.e. `{{ site.baseurl }}/` as typical seen), so I avoid
 them to prevent the editor breaking the line inside the curly braces
 (which upsets Jekyll greatly).
 

--- a/_config.yml
+++ b/_config.yml
@@ -13,7 +13,7 @@ title:            datreant
 tagline:          'persistent, pythonic trees for heterogeneous data'
 description:      'persistent, pythonic trees for heterogeneous data'
 url:              http://datreant.org
-baseurl:          /
+baseurl:
 blog:             /blog
 
 author:

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -15,14 +15,14 @@
   </title>
 
   <!-- CSS -->
-  <link rel="stylesheet" href="{{ site.baseurl }}public/css/poole.css">
-  <link rel="stylesheet" href="{{ site.baseurl }}public/css/syntax.css">
-  <link rel="stylesheet" href="{{ site.baseurl }}public/css/hyde.css">
+  <link rel="stylesheet" href="{{ site.baseurl }}/public/css/poole.css">
+  <link rel="stylesheet" href="{{ site.baseurl }}/public/css/syntax.css">
+  <link rel="stylesheet" href="{{ site.baseurl }}/public/css/hyde.css">
   <link rel="stylesheet" href="http://fonts.googleapis.com/css?family=PT+Sans:400,400italic,700|Abril+Fatface">
 
   <!-- Icons -->
-  <link rel="apple-touch-icon-precomposed" sizes="144x144" href="{{ site.baseurl }}public/apple-touch-icon-144-precomposed.png">
-                                 <link rel="shortcut icon" href="{{ site.baseurl }}public/favicon.ico">
+  <link rel="apple-touch-icon-precomposed" sizes="144x144" href="{{ site.baseurl }}/public/apple-touch-icon-144-precomposed.png">
+                                 <link rel="shortcut icon" href="{{ site.baseurl }}/public/favicon.ico">
 
   <!-- RSS -->
   <link rel="alternate" type="application/rss+xml" title="RSS" href="/atom.xml">

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -2,7 +2,7 @@
   <div class="container sidebar-sticky">
     <div class="sidebar-about">
       <h1>
-        <a href="{{ site.baseurl }}">
+        <a href="{{ site.baseurl }}/">
           {{ site.title }}
         </a>
       </h1>
@@ -10,7 +10,7 @@
     </div>
 
     <nav class="sidebar-nav">
-      <a class="sidebar-nav-item{% if page.url == site.baseurl %} active{% endif %}" href="{{ site.baseurl }}">Home</a>
+      <a class="sidebar-nav-item{% if page.url == site.baseurl %} active{% endif %}" href="{{ site.baseurl }}/">Home</a>
 
       {% comment %}
         The code below dynamically generates a sidebar nav of pages with

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -10,7 +10,8 @@
     </div>
 
     <nav class="sidebar-nav">
-      <a class="sidebar-nav-item{% if page.url == site.baseurl %} active{% endif %}" href="{{ site.baseurl }}/">Home</a>
+      {% assign site_base_url = site.baseurl | append: "/" %}
+      <a class="sidebar-nav-item{% if page.url == site_base_url %} active{% endif %}" href="{{ site.baseurl }}/">Home</a>
 
       {% comment %}
         The code below dynamically generates a sidebar nav of pages with

--- a/index.md
+++ b/index.md
@@ -2,7 +2,7 @@
 layout: default
 title: datreant
 ---
-# [**datreant**]({{site.baseurl}})
+# [**datreant**]({{ site.baseurl }}/)
 
 is a project that seeks to make organic exploration and storage of
 complex scientific data easier to do. It is a Python library built around


### PR DESCRIPTION
- fix #3 (CSS only visible on top-level pages)
- use / *always* after {{site.baseurl}} (see https://github.com/MDAnalysis/MDAnalysis.github.io/issues/16#issuecomment-385572553)

I used the following (with manual touch up for one case)

      git grep -l '{{ site.baseurl }}' | xargs sed -i~ 's|{{ site.baseurl }}|{{ site.baseurl }}/|g'